### PR TITLE
Render items and likes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,74 @@
 import './style.css';
+import getData from './modules/getData.js';
+import getLikes from './modules/getlikes.js';
+import likesShow from './modules/likeShow.js';
+import createAppId from './modules/createAppId.js';
+import postLikes from './modules/postLikes.js';
+
+const mainItemsContainer = document.querySelector('.main_items_container');
+let comments;
+const backdrop = document.querySelector('.backdrop');
+const projectID = 'jz9Xjlf6GBUQcvBtrKpI';
+const dateTime = new Date();
+
+const createCards = async () => {
+  try {
+    let html = '';
+
+    const items = await getData();
+    const { categories } = items;
+
+    const likeID = await getLikes(projectID);
+
+    categories.forEach((category) => {
+      html += `<div id = ${category.idCategory} class="item_contianer">
+                <img src="${category.strCategoryThumb}" alt="">
+                <div class="name_like_conatiner">
+                    <p>${category.strCategory}</p> 
+                    
+                    <div class="likes_heart"> 
+                    <p>${likesShow(likeID, category) ? likesShow(likeID, category) : '0'}</p>
+                    <i class="fas fa-heart"></i>
+                    </div>
+                </div>
+                <button class="comments">Comments</button>
+            </div>`;
+    });
+
+    mainItemsContainer.insertAdjacentHTML('afterbegin', html);
+
+    comments = document.querySelectorAll('.comments');
+    const heartBtn = document.querySelectorAll('.fa-heart');
+
+    comments.forEach((comment, i) => {
+      comment.addEventListener('click', (e) => {
+        const { id } = e.target.closest('.item_contianer');
+
+        const [filteredObj] = categories.filter((category) => category.idCategory === id);
+        // createPopupWindow(filteredObj, i + 1);
+      });
+    });
+
+    heartBtn.forEach((heart) => {
+      heart.addEventListener('click', (e) => {
+        const { id } = e.target.closest('.item_contianer');
+        heart.classList.add('colour_red');
+        let likeCounter = e.target.previousElementSibling.textContent;
+        likeCounter = +likeCounter;
+        likeCounter += 1;
+        e.target.previousElementSibling.textContent = String(likeCounter);
+        postLikes(id, projectID);
+      });
+    });
+    return 'Passed';
+  } catch (err) {
+    return 'something went wrong';
+  }
+};
+
+createCards();
+
+// const closePopup = () => {
+//     backdrop.innerHTML = '';
+//     backdrop.classList.add("hidden");
+// }

--- a/src/modules/createAppId.js
+++ b/src/modules/createAppId.js
@@ -1,0 +1,11 @@
+const createAppId = async () => {
+  const response = await fetch('https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/', {
+    method: 'POST',
+
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+export default createAppId;

--- a/src/modules/getData.js
+++ b/src/modules/getData.js
@@ -1,0 +1,13 @@
+const getData = async () => {
+  try {
+    const response = await fetch('https://www.themealdb.com/api/json/v1/1/categories.php');
+
+    const data = await response.json();
+
+    return data;
+  } catch (err) {
+    return 'something went wrong';
+  }
+};
+
+export default getData;

--- a/src/modules/getlikes.js
+++ b/src/modules/getlikes.js
@@ -1,0 +1,8 @@
+const getLikes = async (projectID) => {
+  const response = await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${projectID}/likes`);
+
+  const data = await response.json();
+  return data;
+};
+
+export default getLikes;

--- a/src/modules/likeShow.js
+++ b/src/modules/likeShow.js
@@ -1,0 +1,10 @@
+const likesShow = (likeID, category) => {
+  const [filteredLikeID] = likeID.filter((idObj) => category.idCategory === idObj.item_id);
+
+  if (filteredLikeID) {
+    return filteredLikeID.likes;
+  }
+  return false;
+};
+
+export default likesShow;

--- a/src/modules/postLikes.js
+++ b/src/modules/postLikes.js
@@ -1,0 +1,15 @@
+const postLikes = async (id, projectID) => {
+  const response = await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${projectID}/likes`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+
+    body: JSON.stringify({
+      item_id: id,
+    }),
+  });
+  return response;
+};
+
+export default postLikes;


### PR DESCRIPTION
# Added items on main page
- Create the main part of the **homepage** that keeps the layout from the **wireframe**.
- When the user clicks on the Like button of an item (on Homepage), the interaction is recorded in the **Involvement API**.
- When the page loads, the webapp the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API.